### PR TITLE
fix: add missing opengl dependency for fedora

### DIFF
--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 ENV OS_NAME=fedora
 RUN dnf makecache \
-    && dnf install -y gcc gcc-c++ make cmake wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel
+    && dnf install -y gcc gcc-c++ make cmake wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel mesa-libGL-devel
 VOLUME /root/dandelion-dev
 VOLUME /root/build_output
 WORKDIR /root


### PR DESCRIPTION
给 fedora 的 Docker 镜像里添加缺少的 `mesa-libGL-devel`。glfw 需要 opengl 的头文件才能编译。