### PR TITLE
支持自动编译动态库和 release channel，并支持指定特定发行版

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-dandelion-dev
-logs
+dandelion
+build_output
 __pycache__

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 ```shell
 $ git clone https://github.com/XJTU-Graphics/dandelion-dev
+$ mv dandelion-dev dandelion
 $ python build_all.py
 ```
 
-构建完毕后，所有的输出都会被存放在 *logs* 目录下，日志文件命名规则为 *[distro name]-[config].log* ，例如 *ubuntu-22.04-debug.log* 就表示 Ubuntu 22.04 下 Debug 模式编译的输出。
+构建完毕后，所有的输出都会被存放在 *build_output* 目录下，日志文件命名规则为 *[distro name]-[config].log* ，例如 *ubuntu-22.04-debug.log* 就表示 Ubuntu 22.04 下 Debug 模式编译的输出。

--- a/build.sh
+++ b/build.sh
@@ -1,28 +1,28 @@
 set -euo pipefail
 
-if [ -z "$1" ]; then
-    BUILD_NAME="dev"
-else
-    BUILD_NAME=$1
-fi
+# Use assumed dandelion path in docker container
+DANDELION_PATH=${DANDELION_PATH:-"../dandelion"}
+BUILD_OUTPUT_PATH=${BUILD_OUTPUT_PATH:-"/root/build_output"}
+
+BUILD_NAME=${1:-"dev"}
 if [ "${BUILD_NAME}" = "dev" ]; then
-    CMAKE_ROOT="../dandelion"
+    CMAKE_ROOT="${DANDELION_PATH}"
     ARTIFACTS_DEBUG="dandelion"
     ARTIFACTS_RELEASE="dandelion"
 elif [ "${BUILD_NAME}" = "dev-lib" ]; then
-    CMAKE_ROOT="../dandelion/lib"
+    CMAKE_ROOT="${DANDELION_PATH}/lib"
     ARTIFACTS_DEBUG="libdandelion-bvh-debug.a libdandelion-ray-debug.a"
     ARTIFACTS_RELEASE="libdandelion-bvh.a libdandelion-ray.a"
 elif [ "${BUILD_NAME}" = "release" ]; then
-    CMAKE_ROOT="../dandelion"
+    CMAKE_ROOT="${DANDELION_PATH}"
     ARTIFACTS_DEBUG="dandelion"
     ARTIFACTS_RELEASE="dandelion"
 fi
 
-DEBUG_LOG="/root/build_output/${OS_NAME}-debug.log"
-RELEASE_LOG="/root/build_output/${OS_NAME}-release.log"
-DEBUG_ARTIFACTS_DIR="/root/build_output/${OS_NAME}-debug-artifacts"
-RELEASE_ARTIFACTS_DIR="/root/build_output/${OS_NAME}-release-artifacts"
+DEBUG_LOG="${BUILD_OUTPUT_PATH}/${OS_NAME}-debug.log"
+RELEASE_LOG="${BUILD_OUTPUT_PATH}/${OS_NAME}-release.log"
+DEBUG_ARTIFACTS_DIR="${BUILD_OUTPUT_PATH}/${OS_NAME}-debug-artifacts"
+RELEASE_ARTIFACTS_DIR="${BUILD_OUTPUT_PATH}/${OS_NAME}-release-artifacts"
 touch ${DEBUG_LOG}
 touch ${RELEASE_LOG}
 chmod 666 ${DEBUG_LOG}

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ if [ "${BUILD_KIND}" = "dev" ]; then
     CMAKE_ROOT="${DANDELION_PATH}"
     ARTIFACTS_DEBUG="dandelion"
     ARTIFACTS_RELEASE="dandelion"
-elif [ "${BUILD_KIND}" = "dev-lib" ]; then
+elif [ "${BUILD_KIND}" = "lib" ]; then
     CMAKE_ROOT="${DANDELION_PATH}/lib"
     ARTIFACTS_DEBUG="libdandelion-bvh-debug.a libdandelion-ray-debug.a"
     ARTIFACTS_RELEASE="libdandelion-bvh.a libdandelion-ray.a"
@@ -18,6 +18,9 @@ elif [ "${BUILD_KIND}" = "release" ]; then
     CMAKE_ROOT="${DANDELION_PATH}"
     ARTIFACTS_DEBUG="dandelion"
     ARTIFACTS_RELEASE="dandelion"
+else
+    echo "Please specify a valid build kind (dev, lib, release)" 1>&2
+    exit 1
 fi
 
 DEBUG_LOG="${BUILD_OUTPUT_PATH}/${OS_NAME}-debug.log"

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,9 @@
 set -euo pipefail
 
 # Use assumed dandelion path in docker container
-DANDELION_PATH=${DANDELION_PATH:-"../dandelion"}
-BUILD_OUTPUT_PATH=${BUILD_OUTPUT_PATH:-"/root/build_output"}
+DANDELION_PATH=${DANDELION_PATH:-"dandelion"}
+BUILD_PATH=${BUILD_PATH:-"build"}
+BUILD_OUTPUT_PATH=${BUILD_OUTPUT_PATH:-"build_output"}
 
 BUILD_NAME=${1:-"dev"}
 if [ "${BUILD_NAME}" = "dev" ]; then
@@ -30,27 +31,24 @@ chmod 666 ${RELEASE_LOG}
 mkdir -p ${DEBUG_ARTIFACTS_DIR}
 mkdir -p ${RELEASE_ARTIFACTS_DIR}
 
-mkdir build
-cd build
-
 echo "configure dandelion(${BUILD_NAME}) (debug)"
-cmake -S ${CMAKE_ROOT} -B . -DCMAKE_BUILD_TYPE=Debug 2>&1 | tee ${DEBUG_LOG}
+cmake -S ${CMAKE_ROOT} -B ${BUILD_PATH} -DCMAKE_BUILD_TYPE=Debug 2>&1 | tee ${DEBUG_LOG}
 echo 'done'
 echo "building dandelion(${BUILD_NAME}) (debug)"
-cmake --build . --parallel $(nproc) 2>&1 | tee -a ${DEBUG_LOG}
+cmake --build ${BUILD_PATH} --parallel $(nproc) 2>&1 | tee -a ${DEBUG_LOG}
 echo 'done'
 
 for artifact in ${ARTIFACTS_DEBUG}; do
-    cp "./$artifact" ${DEBUG_ARTIFACTS_DIR}/
+    cp "${BUILD_PATH}/$artifact" ${DEBUG_ARTIFACTS_DIR}/
 done
 
 echo "configure dandelion(${BUILD_NAME}) (release)"
-cmake -S ${CMAKE_ROOT} -B . -DCMAKE_BUILD_TYPE=Release 2>&1 | tee ${RELEASE_LOG}
+cmake -S ${CMAKE_ROOT} -B ${BUILD_PATH} -DCMAKE_BUILD_TYPE=Release 2>&1 | tee ${RELEASE_LOG}
 echo 'done'
 echo "building dandelion(${BUILD_NAME}) (release)"
-cmake --build . --parallel $(nproc) 2>&1 | tee -a ${RELEASE_LOG}
+cmake --build ${BUILD_PATH} --parallel $(nproc) 2>&1 | tee -a ${RELEASE_LOG}
 echo 'done'
 
 for artifact in ${ARTIFACTS_RELEASE}; do
-    cp "./$artifact" ${RELEASE_ARTIFACTS_DIR}/
+    cp "${BUILD_PATH}/$artifact" ${RELEASE_ARTIFACTS_DIR}/
 done

--- a/build.sh
+++ b/build.sh
@@ -1,31 +1,56 @@
 set -euo pipefail
 
-DEBUG_LOG=/root/build_output/${OS_NAME}-debug.log
-RELEASE_LOG=/root/build_output/${OS_NAME}-release.log
-ARTIFACTS_DIR=/root/build_output/${OS_NAME}-artifacts
+if [ -z "$1" ]; then
+    BUILD_NAME="dev"
+else
+    BUILD_NAME=$1
+fi
+if [ "${BUILD_NAME}" = "dev" ]; then
+    CMAKE_ROOT="../dandelion"
+    ARTIFACTS_DEBUG="dandelion"
+    ARTIFACTS_RELEASE="dandelion"
+elif [ "${BUILD_NAME}" = "dev-lib" ]; then
+    CMAKE_ROOT="../dandelion/lib"
+    ARTIFACTS_DEBUG="libdandelion-bvh-debug.a libdandelion-ray-debug.a"
+    ARTIFACTS_RELEASE="libdandelion-bvh.a libdandelion-ray.a"
+elif [ "${BUILD_NAME}" = "release" ]; then
+    CMAKE_ROOT="../dandelion"
+    ARTIFACTS_DEBUG="dandelion"
+    ARTIFACTS_RELEASE="dandelion"
+fi
+
+DEBUG_LOG="/root/build_output/${OS_NAME}-debug.log"
+RELEASE_LOG="/root/build_output/${OS_NAME}-release.log"
+DEBUG_ARTIFACTS_DIR="/root/build_output/${OS_NAME}-debug-artifacts"
+RELEASE_ARTIFACTS_DIR="/root/build_output/${OS_NAME}-release-artifacts"
 touch ${DEBUG_LOG}
 touch ${RELEASE_LOG}
 chmod 666 ${DEBUG_LOG}
 chmod 666 ${RELEASE_LOG}
-mkdir -p ${ARTIFACTS_DIR}
+mkdir -p ${DEBUG_ARTIFACTS_DIR}
+mkdir -p ${RELEASE_ARTIFACTS_DIR}
 
 mkdir build
 cd build
 
-echo 'configure dandelion (debug)...'
-cmake -S ../dandelion-dev -B . -DCMAKE_BUILD_TYPE=Debug 2>&1 | tee ${DEBUG_LOG}
+echo "configure dandelion(${BUILD_NAME}) (debug)"
+cmake -S ${CMAKE_ROOT} -B . -DCMAKE_BUILD_TYPE=Debug 2>&1 | tee ${DEBUG_LOG}
 echo 'done'
-echo 'building dandelion...'
+echo "building dandelion(${BUILD_NAME}) (debug)"
 cmake --build . --parallel $(nproc) 2>&1 | tee -a ${DEBUG_LOG}
 echo 'done'
 
-cp ./dandelion ${ARTIFACTS_DIR}/dandelion-debug
+for artifact in ${ARTIFACTS_DEBUG}; do
+    cp "./$artifact" ${DEBUG_ARTIFACTS_DIR}/
+done
 
-echo 'configure dandelion (release)...'
-cmake -S ../dandelion-dev -B . -DCMAKE_BUILD_TYPE=Release 2>&1 | tee ${RELEASE_LOG}
+echo "configure dandelion(${BUILD_NAME}) (release)"
+cmake -S ${CMAKE_ROOT} -B . -DCMAKE_BUILD_TYPE=Release 2>&1 | tee ${RELEASE_LOG}
 echo 'done'
-echo 'building dandelion...'
+echo "building dandelion(${BUILD_NAME}) (release)"
 cmake --build . --parallel $(nproc) 2>&1 | tee -a ${RELEASE_LOG}
 echo 'done'
 
-cp ./dandelion ${ARTIFACTS_DIR}/dandelion-release
+for artifact in ${ARTIFACTS_RELEASE}; do
+    cp "./$artifact" ${RELEASE_ARTIFACTS_DIR}/
+done

--- a/build.sh
+++ b/build.sh
@@ -5,16 +5,16 @@ DANDELION_PATH=${DANDELION_PATH:-"dandelion"}
 BUILD_PATH=${BUILD_PATH:-"build"}
 BUILD_OUTPUT_PATH=${BUILD_OUTPUT_PATH:-"build_output"}
 
-BUILD_NAME=${1:-"dev"}
-if [ "${BUILD_NAME}" = "dev" ]; then
+BUILD_KIND=${1:-"dev"}
+if [ "${BUILD_KIND}" = "dev" ]; then
     CMAKE_ROOT="${DANDELION_PATH}"
     ARTIFACTS_DEBUG="dandelion"
     ARTIFACTS_RELEASE="dandelion"
-elif [ "${BUILD_NAME}" = "dev-lib" ]; then
+elif [ "${BUILD_KIND}" = "dev-lib" ]; then
     CMAKE_ROOT="${DANDELION_PATH}/lib"
     ARTIFACTS_DEBUG="libdandelion-bvh-debug.a libdandelion-ray-debug.a"
     ARTIFACTS_RELEASE="libdandelion-bvh.a libdandelion-ray.a"
-elif [ "${BUILD_NAME}" = "release" ]; then
+elif [ "${BUILD_KIND}" = "release" ]; then
     CMAKE_ROOT="${DANDELION_PATH}"
     ARTIFACTS_DEBUG="dandelion"
     ARTIFACTS_RELEASE="dandelion"
@@ -31,10 +31,10 @@ chmod 666 ${RELEASE_LOG}
 mkdir -p ${DEBUG_ARTIFACTS_DIR}
 mkdir -p ${RELEASE_ARTIFACTS_DIR}
 
-echo "configure dandelion(${BUILD_NAME}) (debug)"
+echo "configure dandelion(${BUILD_KIND}) (debug)"
 cmake -S ${CMAKE_ROOT} -B ${BUILD_PATH} -DCMAKE_BUILD_TYPE=Debug 2>&1 | tee ${DEBUG_LOG}
 echo 'done'
-echo "building dandelion(${BUILD_NAME}) (debug)"
+echo "building dandelion(${BUILD_KIND}) (debug)"
 cmake --build ${BUILD_PATH} --parallel $(nproc) 2>&1 | tee -a ${DEBUG_LOG}
 echo 'done'
 
@@ -42,10 +42,10 @@ for artifact in ${ARTIFACTS_DEBUG}; do
     cp "${BUILD_PATH}/$artifact" ${DEBUG_ARTIFACTS_DIR}/
 done
 
-echo "configure dandelion(${BUILD_NAME}) (release)"
+echo "configure dandelion(${BUILD_KIND}) (release)"
 cmake -S ${CMAKE_ROOT} -B ${BUILD_PATH} -DCMAKE_BUILD_TYPE=Release 2>&1 | tee ${RELEASE_LOG}
 echo 'done'
-echo "building dandelion(${BUILD_NAME}) (release)"
+echo "building dandelion(${BUILD_KIND}) (release)"
 cmake --build ${BUILD_PATH} --parallel $(nproc) 2>&1 | tee -a ${RELEASE_LOG}
 echo 'done'
 

--- a/build_all.py
+++ b/build_all.py
@@ -18,9 +18,13 @@ def update_archlinux():
     else:
         logging.warn('cannot update archlinux image, build may fail for such a rolling distribution')
 
-def build_images(use_mirror):
-    logging.info('build all docker images...')
-    for dockerfile in dockerfiles.iterdir():
+def build_images(image_list, use_mirror):
+    if image_list is None:
+        image_files = dockerfiles.iterdir()
+    else:
+        image_files = (Path(x) for x in image_list)
+    logging.info('build docker images: {}'.format(image_files))
+    for dockerfile in image_files:
         os_name = dockerfile.stem
         image_name = f'dandelion_builder:{os_name}'
         logging.info(f'build builder image {image_name}')
@@ -40,9 +44,13 @@ def build_images(use_mirror):
             logging.warning('failed')
     logging.info('done')
 
-def build_dandelion():
-    logging.info('run auto-build with all builder images...')
-    os_names = [dockerfile.stem for dockerfile in dockerfiles.iterdir()]
+def build_dandelion(image_list, build_name):
+    if image_list is None:
+        image_files = dockerfiles.iterdir()
+    else:
+        image_files = (Path(x) for x in image_list)
+    logging.info('run auto-build with: {}'.format(image_files))
+    os_names = [dockerfile.stem for dockerfile in image_files]
     all_passed = True
     for os_name in os_names:
         container_name = f'dandelion_builder_{os_name}'
@@ -50,10 +58,11 @@ def build_dandelion():
         build_cmd = [
             'docker', 'run',
             '--name', container_name,
-            '-v', './dandelion-dev:/root/dandelion-dev:ro',
-            '-v', './logs:/root/build_output',
+            '-v', './dandelion:/root/dandelion:ro',
+            '-v', './build_output:/root/build_output',
             '--net', 'host',
-            f'dandelion_builder:{os_name}'
+            f'dandelion_builder:{os_name}',
+            build_name
         ]
         clear_cmd = ['docker', 'container', 'rm', '-f', container_name]
         try:
@@ -76,19 +85,21 @@ def build_dandelion():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-u', '--update', help='update the rolling distribution images', action='store_true')
-    parser.add_argument('-im', '--build_images', '--build-images', help='build all builder images', action='store_true')
+    parser.add_argument('-i', '--image', help='select which image to use', nargs='*')
+    parser.add_argument('--build-images', help='build all builder images', action='store_true')
     parser.add_argument('-b', '--build', help='build dandelion with each builder image', action='store_true')
+    parser.add_argument('--build-name', help='which version and thing to build, dev/dev-lib/release')
     parser.add_argument('--use-mirror', help='use "mirrors.tuna.tsinghua.edu.cn" for updating system packages', action='store_true')
     args = parser.parse_args()
     if args.update:
         update_archlinux()
     if args.build_images:
-        build_images(args.use_mirror)
+        build_images(args.image, args.use_mirror)
     if args.build:
-        all_passed = build_dandelion()
+        all_passed = build_dandelion(args.image, args.build_name)
         sys.exit(not all_passed)
     if not any([args.update, args.build_images, args.build]):
         update_archlinux()
-        build_images(args.use_mirror)
-        all_passed = build_dandelion()
+        build_images(args.image, args.use_mirror)
+        all_passed = build_dandelion(args.image, args.build_name)
         sys.exit(not all_passed)

--- a/build_all.py
+++ b/build_all.py
@@ -44,7 +44,7 @@ def build_images(image_list, use_mirror):
             logging.warning('failed')
     logging.info('done')
 
-def build_dandelion(image_list, build_name):
+def build_dandelion(image_list, build_kind):
     if image_list is None:
         image_files = dockerfiles.iterdir()
     else:
@@ -62,7 +62,7 @@ def build_dandelion(image_list, build_name):
             '-v', './build_output:/root/build_output',
             '--net', 'host',
             f'dandelion_builder:{os_name}',
-            build_name
+            build_kind
         ]
         clear_cmd = ['docker', 'container', 'rm', '-f', container_name]
         try:
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     parser.add_argument('-i', '--image', help='select which image to use', nargs='*')
     parser.add_argument('--build-images', help='build all builder images', action='store_true')
     parser.add_argument('-b', '--build', help='build dandelion with each builder image', action='store_true')
-    parser.add_argument('--build-name', help='which version and thing to build, dev/dev-lib/release')
+    parser.add_argument('--build-kind', help='which version and thing to build, dev/dev-lib/release')
     parser.add_argument('--use-mirror', help='use "mirrors.tuna.tsinghua.edu.cn" for updating system packages', action='store_true')
     args = parser.parse_args()
     if args.update:
@@ -96,10 +96,10 @@ if __name__ == '__main__':
     if args.build_images:
         build_images(args.image, args.use_mirror)
     if args.build:
-        all_passed = build_dandelion(args.image, args.build_name)
+        all_passed = build_dandelion(args.image, args.build_kind)
         sys.exit(not all_passed)
     if not any([args.update, args.build_images, args.build]):
         update_archlinux()
         build_images(args.image, args.use_mirror)
-        all_passed = build_dandelion(args.image, args.build_name)
+        all_passed = build_dandelion(args.image, args.build_kind)
         sys.exit(not all_passed)

--- a/dockerfiles/archlinux.Dockerfile
+++ b/dockerfiles/archlinux.Dockerfile
@@ -7,8 +7,8 @@ RUN if [ "$use_mirror" = "true" ]; then \
     fi; \
     pacman -Syyu --noconfirm \
     && pacman -S --noconfirm gcc make cmake xorg
-VOLUME /root/dandelion-dev
+VOLUME /root/dandelion
 VOLUME /root/build_output
 WORKDIR /root
 COPY build.sh /root
-CMD ["/bin/bash", "/root/build.sh"]
+ENTRYPOINT ["/bin/bash", "/root/build.sh"]

--- a/dockerfiles/debian-12.Dockerfile
+++ b/dockerfiles/debian-12.Dockerfile
@@ -7,8 +7,8 @@ RUN if [ "$use_mirror" = "true" ]; then \
     fi; \
     apt-get update \
     && apt-get install -y build-essential cmake libwayland-dev libxkbcommon-dev xorg-dev
-VOLUME /root/dandelion-dev
+VOLUME /root/dandelion
 VOLUME /root/build_output
 WORKDIR /root
 COPY build.sh /root
-CMD ["/bin/bash", "/root/build.sh"]
+ENTRYPOINT ["/bin/bash", "/root/build.sh"]

--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -2,8 +2,8 @@ FROM fedora:latest
 ENV OS_NAME=fedora
 RUN dnf makecache \
     && dnf install -y gcc gcc-c++ make cmake wayland-devel libxkbcommon-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel mesa-libGL-devel
-VOLUME /root/dandelion-dev
+VOLUME /root/dandelion
 VOLUME /root/build_output
 WORKDIR /root
 COPY build.sh /root
-CMD ["/bin/bash", "/root/build.sh"]
+ENTRYPOINT ["/bin/bash", "/root/build.sh"]

--- a/dockerfiles/ubuntu-22.04.Dockerfile
+++ b/dockerfiles/ubuntu-22.04.Dockerfile
@@ -7,8 +7,8 @@ RUN if [ "$use_mirror" = "true" ]; then \
     fi; \
     apt-get update \
     && apt-get install -y build-essential cmake libwayland-dev libxkbcommon-dev xorg-dev
-VOLUME /root/dandelion-dev
+VOLUME /root/dandelion
 VOLUME /root/build_output
 WORKDIR /root
 COPY build.sh /root
-CMD ["/bin/bash", "/root/build.sh"]
+ENTRYPOINT ["/bin/bash", "/root/build.sh"]

--- a/dockerfiles/ubuntu-24.04.Dockerfile
+++ b/dockerfiles/ubuntu-24.04.Dockerfile
@@ -8,8 +8,8 @@ RUN if [ "$use_mirror" = "true" ]; then \
     cat /etc/apt/sources.list; \
     apt-get update \
     && apt-get install -y build-essential cmake libwayland-dev libxkbcommon-dev xorg-dev
-VOLUME /root/dandelion-dev
+VOLUME /root/dandelion
 VOLUME /root/build_output
 WORKDIR /root
 COPY build.sh /root
-CMD ["/bin/bash", "/root/build.sh"]
+ENTRYPOINT ["/bin/bash", "/root/build.sh"]


### PR DESCRIPTION
为支持 dandelion release channel 自动构建和提高性能( https://github.com/XJTU-Graphics/dandelion-dev/issues/10 )做出一些修改：

- 添加编译种类 build_kind，支持在 dev channel 自动编译动态库，支持 release channel 的编译方式
- `build.sh` 中涉及的几个工作路径均使用环境变量传入，方便脚本兼容 windows mingw bash 环境
- 可指定特定发行版，只编译某个发行版，方便 actions 里面并行编译

为方便多个 build_kind 构建和 artifact 输出，也改变了几个工作目录的名称，会与改动前不兼容

 dandelion-dev 将相应改动 [ci_lib_and_release](https://github.com/XJTU-Graphics/dandelion-dev/tree/ci_lib_and_release)  分支